### PR TITLE
Build using CMake wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(cmake_wrapper)
 
-include(conanbuildinfo.cmake)
+include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 add_subdirectory(sources)

--- a/build.py
+++ b/build.py
@@ -68,5 +68,5 @@ if __name__ == "__main__":
         upload_only_when_stable=True,
         stable_branch_pattern="stable/*")
 
-    builder.add_common_builds(shared_option_name=name + ":shared")
+    builder.add_common_builds(shared_option_name=name + ":shared", pure_c=False)
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,15 +8,16 @@ import os
 class Base64Conan(ConanFile):
     name = "base64"
     version = "1.0.2"
-    creator = "DEGoodmanWilson"
-    url = "https://github.com/{0}/conan-{1}".format(creator, name)
+    generators = "cmake"
+    author = "DEGoodmanWilson"
+    url = "https://github.com/{0}/conan-{1}".format(author, name)
     description = "Base64 encode and decode routines by René Nyffenegger"
-    license = "https://github.com/{0}/conan-{1}/blob/master/LICENSES".format(creator, name)
+    license = "https://github.com/{0}/conan-{1}/blob/master/LICENSES".format(author, name)
     exports_sources = ["CMakeLists.txt", "LICENSE"]
     settings = "os", "arch", "compiler", "build_type"
     options = {"shared": [True, False], "build_tests": [True, False]}
     default_options = "shared=False", "build_tests=False"
-        
+
     def requirements(self):
         #use dynamic org/channel for libs in DEGoodmanWilson
         if self.options.build_tests:
@@ -24,7 +25,7 @@ class Base64Conan(ConanFile):
             self.options["gtest"].shared = self.options["shared"]
 
     def source(self):
-        source_url = "https://github.com/{0}/{1}".format(self.creator, self.name)
+        source_url = "https://github.com/{0}/{1}".format(self.author, self.name)
         tools.get("{0}/archive/v{1}.tar.gz".format(source_url, self.version))
         extracted_dir = self.name + "-" + self.version
         os.rename(extracted_dir, "sources")
@@ -33,7 +34,7 @@ class Base64Conan(ConanFile):
     def build(self):
         cmake = CMake(self)
         cmake.definitions["BUILD_BASE64_TESTS"] = self.options.build_tests
-        cmake.configure(source_dir="sources")
+        cmake.configure()
         cmake.build()
 
     def package(self):


### PR DESCRIPTION
- Fix cmake helper call to use CMake wrapper to base64's cmake file
- Replaced 'creator' by 'author'. Author is the standard convention
- Added pure_c=False on build to link libstdc++11 on gcc>=5

Signed-off-by: Uilian Ries <uilianries@gmail.com>